### PR TITLE
Added nav entries for new math tests

### DIFF
--- a/content/30/epub30-test-0100/EPUB/xhtml/nav.xhtml
+++ b/content/30/epub30-test-0100/EPUB/xhtml/nav.xhtml
@@ -65,6 +65,12 @@
 								<li><a href="content-mathml-001.xhtml#mathml-021">CSS Styling of <code>mo</code></a></li>
 								<li><a href="content-mathml-001.xhtml#mathml-022">CSS Styling of <code>mi</code></a></li>
 								<li><a href="content-mathml-001.xhtml#mathml-023">CSS Styling of <code>mn</code></a></li>
+
+								<li><a href="content-mathml-001.xhtml#mathml-024">Horizontal stretch, <code>mover</code>, <code>munder</code>, and <code>mspace</code> elements</a></li>
+								<li><a href="content-mathml-001.xhtml#mathml-025">Testing <code>mtable</code> with <code>colspan</code> and <code>rowspan</code> attributes, Hebrew and Script fonts</a></li>
+								<li><a href="content-mathml-001.xhtml#mathml-026">BiDi, RTL and Arabic alphabets</a></li>
+								<li><a href="content-mathml-001.xhtml#mathml-027">Elementary math: long division notation</a></li>
+								<li><a href="content-mathml-001.xhtml#mathml-028">Multiscripts, Greek and Gothic alphabets</a></li>
 							</ol>
 						</li>
 						<li class="category"><a href="content-svg-001.xhtml#svg">SVG</a>


### PR DESCRIPTION
The newest MathML tests were missing corresponding entries in nav.xhtml
