### PR TITLE
Improved epub:switch test in document 0100

### DIFF
--- a/content/30/epub30-test-0100/EPUB/xhtml/content-switch-001.xhtml
+++ b/content/30/epub30-test-0100/EPUB/xhtml/content-switch-001.xhtml
@@ -18,9 +18,9 @@
         		
         		<epub:switch>
         			<epub:case required-namespace="http://www.example.com/unsupported/namespace">
-        				<element xmlns="http://www.example.com/unsupported/namespace">
+        				<p>
         					FAIL
-        				</element>
+        				</p>
         			</epub:case>
         			<epub:default>
         				<p id="fallback">


### PR DESCRIPTION
Reading systems may ignore content in unrecognised elements, thus
excluding the 'FAIL' text in the switch-010 test. Changing the
epub:case branch to use a <p> element instead means that only the
behaviour of processing the epub:switch statement is tested.

This fixes https://github.com/mgylling/epub-testsuite/issues/48
